### PR TITLE
Add optional mandatory-users and mandatory-groups

### DIFF
--- a/sample_repo_configuration.yml
+++ b/sample_repo_configuration.yml
@@ -115,6 +115,9 @@ wz-branch-reviewers:
       - senior.dev2
     groups:
       - project.developers
+    mandatory-users:
+      - the.boss
+    mandatory-groups: []
     paths: # path specific reviewers
       - path: "frontend/**/*.css"
         users:

--- a/src/bec_config_ss.erl
+++ b/src/bec_config_ss.erl
@@ -175,7 +175,11 @@ from_permission_type('REPO_READ')  -> read.
 -spec to_wz_branch_reviewer(map()) -> bec_wz_branch_reviewer_t:reviewer().
 to_wz_branch_reviewer(#{<<"paths">> := Paths} = R0) ->
   R = R0#{<<"paths">> => lists:sort([atomify_keys(P) || P <- Paths])},
-  atomify_keys(R).
+  Mandatory = #{<<"mandatory-users">>  => []
+              , <<"mandatory-groups">> => []
+              },
+  Merged = maps:merge(Mandatory, R),
+  atomify_keys(Merged).
 
 -spec atomify_keys(map()) -> map().
 atomify_keys(Map) ->

--- a/src/bec_wz_branch_reviewer_t.erl
+++ b/src/bec_wz_branch_reviewer_t.erl
@@ -13,10 +13,12 @@
 %%==============================================================================
 %% Types
 %%==============================================================================
--type reviewer() :: #{ 'branch-id' := bec_branch_t:id()
-                     , users       := [bec_wz_user_t:name()]
-                     , groups      := [bec_group_t:name()]
-                     , paths       := [bec_wz_path_t:path()]
+-type reviewer() :: #{ 'branch-id'        := bec_branch_t:id()
+                     , users              := [bec_wz_user_t:name()]
+                     , groups             := [bec_group_t:name()]
+                     , paths              := [bec_wz_path_t:path()]
+                     , 'mandatory-users'  := [bec_wz_user_t:name()]
+                     , 'mandatory-groups' := [bec_group_t:name()]
                      }.
 
 %%==============================================================================
@@ -34,24 +36,31 @@ from_map(#{ <<"refName">>           := RefName
           } = Map) ->
   %% filePathReviewers are not always present in the response from BitBucket
   FPR = maps:get(<<"filePathReviewers">>, Map, []),
-  #{ 'branch-id' => bec_wz_utils:strip_prefix(RefName)
-   , users       => lists:sort([bec_wz_user_t:from_map(U) || U <- Users])
-   , groups      => lists:sort(Groups)
-   , paths       => lists:sort([bec_wz_path_t:from_map(P) || P <- FPR])
+  MUsers = maps:get(<<"mandatoryUsers">>, Map, []),
+  MGroups = maps:get(<<"mandatoryGroups">>, Map, []),
+  #{ 'branch-id'        => bec_wz_utils:strip_prefix(RefName)
+   , users              => lists:sort([bec_wz_user_t:from_map(U) || U <- Users])
+   , groups             => lists:sort(Groups)
+   , paths              => lists:sort([bec_wz_path_t:from_map(P) || P <- FPR])
+   , 'mandatory-users'  => lists:sort([bec_wz_user_t:from_map(U)
+                                        || U <- MUsers])
+   , 'mandatory-groups' => lists:sort(MGroups)
    }.
 
 -spec to_map(reviewer()) -> map().
-to_map(#{ 'branch-id' := BranchId
-        , users       := Users
-        , groups      := Groups
-        , paths       := Paths
-        }) ->
+to_map(#{ 'branch-id'             := BranchId
+        , users                   := Users
+        , groups                  := Groups
+        , paths                   := Paths
+        } = Map) ->
+  MUsers = maps:get('mandatory-users', Map, []),
+  MGroups = maps:get('mandatory-groups', Map, []),
   #{ <<"refName">>               => bec_wz_utils:add_prefix(BranchId)
    , <<"users">>                 => [bec_wz_user_t:to_map(U) || U <- Users]
    , <<"groups">>                => Groups
    , <<"filePathReviewers">>     => [bec_wz_path_t:to_map(P) || P <- Paths]
-   , <<"mandatoryUsers">>        => []
-   , <<"mandatoryGroups">>       => []
+   , <<"mandatoryUsers">>        => [bec_wz_user_t:to_map(U) || U <- MUsers]
+   , <<"mandatoryGroups">>       => MGroups
    , <<"topSuggestedReviewers">> => 0
    , <<"daysInPast">>            => 0
    }.

--- a/test/bec_config_ss_SUITE.erl
+++ b/test/bec_config_ss_SUITE.erl
@@ -1,0 +1,64 @@
+%%==============================================================================
+%% Test Suite for config syntactic sugar
+%%==============================================================================
+
+-module(bec_config_ss_SUITE).
+
+%% Common Test Callbacks
+-export([ all/0 ]).
+
+%% Testcases
+-export([ to_wz_branch_reviewers_adds_default_mandatory/1 
+        , to_wz_branch_reviewers_keeps_original_mandatory/1
+        ]).
+
+%%==============================================================================
+%% Include
+%%==============================================================================
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+all() ->
+  [ to_wz_branch_reviewers_adds_default_mandatory
+  , to_wz_branch_reviewers_keeps_original_mandatory
+  ].
+
+to_wz_branch_reviewers_adds_default_mandatory(_Config) ->
+  Reviewers = 
+    [ #{ <<"branch-id">> => <<"master">>
+       , <<"groups">>    => []
+       , <<"paths">>     => []
+       , <<"users">>     => []
+       }
+    ],
+  ExpectedResult =
+    [ #{ 'branch-id'        => <<"master">>
+       , 'groups'           => []
+       , 'paths'            => []
+       , 'users'            => []
+       , 'mandatory-users'  => []
+       , 'mandatory-groups' => []
+       }
+      ],
+  ?assertEqual(ExpectedResult, bec_config_ss:to_wz_branch_reviewers(Reviewers)).
+
+to_wz_branch_reviewers_keeps_original_mandatory(_Config) ->
+  Reviewers = 
+    [ #{ <<"branch-id">>        => <<"master">>
+       , <<"groups">>           => []
+       , <<"paths">>            => []
+       , <<"users">>            => []
+       , <<"mandatory-users">>  => [ <<"user.a">> ]
+       , <<"mandatory-groups">> => [ <<"group.a">> ]
+       }
+    ],
+  ExpectedResult =
+    [ #{ 'branch-id'        => <<"master">>
+       , 'groups'           => []
+       , 'paths'            => []
+       , 'users'            => []
+       , 'mandatory-users'  => [ <<"user.a">> ]
+       , 'mandatory-groups' => [ <<"group.a">> ]
+       }
+      ],
+  ?assertEqual(ExpectedResult, bec_config_ss:to_wz_branch_reviewers(Reviewers)).

--- a/test/bec_proper_gen.erl
+++ b/test/bec_proper_gen.erl
@@ -41,6 +41,15 @@ groups() ->
   unique_list(group(), {map, groupname}).
 
 %%==============================================================================
+%% Mandatory attributes
+%%==============================================================================
+mandatory_users() ->
+  unique_list(username()).
+
+mandatory_groups() ->
+  unique_list(groupname()).
+
+%%==============================================================================
 %% Permission User
 %%==============================================================================
 permission_type() ->
@@ -180,12 +189,14 @@ wz_branch_reviewers() ->
   unique_list(wz_branch_reviewer(), {map, 'branch-id'}).
 
 wz_branch_reviewer() ->
-  ?LET( {BranchId, Users, Groups, Paths}
-      , {branch_id(), usernames(), groupnames(), unique_list(wz_path())}
-      , #{ 'branch-id' => BranchId
-         , users       => Users
-         , groups      => Groups
-         , paths       => Paths
+  ?LET( {BranchId, Users, Groups, Paths, MandatoryUsers, MandatoryGroups}
+      , {branch_id(), usernames(), groupnames(), unique_list(wz_path()), mandatory_users(), mandatory_groups()}
+      , #{ 'branch-id'        => BranchId
+         , users              => Users
+         , groups             => Groups
+         , paths              => Paths
+         , 'mandatory-users'  => MandatoryUsers
+         , 'mandatory-groups' => MandatoryGroups
          }).
 
 wz_path() ->

--- a/test/bitbucket_api_SUITE_data/get_wz_branch_reviewers_with_mandatory.json
+++ b/test/bitbucket_api_SUITE_data/get_wz_branch_reviewers_with_mandatory.json
@@ -1,0 +1,49 @@
+[
+  {
+    "projectKey": "a_project",
+    "repoSlug": "a_repo",
+    "refName": "refs/heads/integration",
+    "users": [
+      {
+        "name": "user.a"
+      }
+    ],
+    "groups": [
+      "group.a"
+    ],
+    "mandatoryUsers": [
+      {
+        "name": "user.a"
+      }
+    ],
+    "mandatoryGroups": [
+      "group.a"
+    ],
+    "topSuggestedReviewers": 0,
+    "daysInPast": 0,
+    "filePathReviewers": [
+      {
+        "filePathPattern": "lib/**",
+        "includeExcludeEnabled": false,
+        "users": [
+          {
+            "name": "user.b"
+          }
+        ],
+        "groups": [],
+        "mandatoryUsers": [],
+        "mandatoryGroups": []
+      },
+      {
+        "filePathPattern": "another_lib/**",
+        "includeExcludeEnabled": false,
+        "users": [],
+        "groups": [
+          "group.b"
+        ],
+        "mandatoryUsers": [],
+        "mandatoryGroups": []
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Right now we don't have ability to define mandatory users and groups in the `wz-branch-reviewers` section. Proposed syntax is as follows:

```yaml
wz-branch-reviewers:
  - branch-id: master
    users: []
    groups: []
    paths: []
    mandatory-users: [user.a]
    mandatory-groups: [group.a]
```

Since lots of projects are already using BEC, the new "mandatory-" keywords will be optional to add, not to break existing configs.