### PR TITLE
Add options to specify mandatory reviewer in path

### DIFF
--- a/sample_repo_configuration.yml
+++ b/sample_repo_configuration.yml
@@ -68,8 +68,8 @@ hooks:
   - key: "de.aeffle.stash.plugin.stash-http-get-post-receive-hook:http-get-post-receive-hook"
     enabled: true
     settings:
-      locationCount: '2' # The plugin requires an explicit count of how many hooks are set
-      version: '3' # Plugin's API version
+      locationCount: "2" # The plugin requires an explicit count of how many hooks are set
+      version: "3" # Plugin's API version
       branchFilter: ^((proj)|(PROJ))\-.*
       httpMethod: POST
       tagFilter: ^$
@@ -87,10 +87,10 @@ hooks:
 
 # PR Restrictions
 pr-restrictions:
-  required-all-approvers : true
-  required-all-tasks-complete : true
-  required-approvers : 2
-  required-successful-builds : 1
+  required-all-approvers: true
+  required-all-tasks-complete: true
+  required-approvers: 2
+  required-successful-builds: 1
   merge-config:
     default-strategy: no-ff
     enabled-strategies:
@@ -104,7 +104,7 @@ pr-restrictions:
 wz-pr-restrictions:
   - branch-id: develop
     approval-quota: 0 # The percentage of individuals reviewing a PR who must approve it before it can be merged
-    group-quota: 1   # Minimum number of approvals required per group
+    group-quota: 1 # Minimum number of approvals required per group
 
 # Workzone Branch Reviewers
 wz-branch-reviewers:
@@ -125,6 +125,11 @@ wz-branch-reviewers:
           - ux.expert2
         groups:
           - designers
+        mandatory-users:
+          - senior.dev1
+          - senior.dev2
+        mandatory-groups:
+          - project.developers
 
 # Workzone Flow
 wz-workflow:

--- a/src/bec_config_ss.erl
+++ b/src/bec_config_ss.erl
@@ -174,11 +174,9 @@ from_permission_type('REPO_READ')  -> read.
 
 -spec to_wz_branch_reviewer(map()) -> bec_wz_branch_reviewer_t:reviewer().
 to_wz_branch_reviewer(#{<<"paths">> := Paths} = R0) ->
-  R = R0#{<<"paths">> => lists:sort([atomify_keys(P) || P <- Paths])},
-  Mandatory = #{<<"mandatory-users">>  => []
-              , <<"mandatory-groups">> => []
-              },
-  Merged = maps:merge(Mandatory, R),
+  AtomifyMap = [atomify_keys(add_default_mandatory(P)) || P <- Paths],
+  R = R0#{<<"paths">> => lists:sort(AtomifyMap)},
+  Merged = add_default_mandatory(R),
   atomify_keys(Merged).
 
 -spec atomify_keys(map()) -> map().
@@ -187,3 +185,9 @@ atomify_keys(Map) ->
           maps:put(binary_to_atom(K, utf8), V, Acc)
       end,
   maps:fold(F, #{}, Map).
+
+-spec add_default_mandatory(map()) -> map().
+add_default_mandatory(WZMap) ->
+  Mandatory = #{ <<"mandatory-users">> => []
+                , <<"mandatory-groups">> => []},
+  maps:merge(Mandatory,WZMap).

--- a/src/bec_wz_branch_reviewer_t.erl
+++ b/src/bec_wz_branch_reviewer_t.erl
@@ -43,7 +43,7 @@ from_map(#{ <<"refName">>           := RefName
    , groups             => lists:sort(Groups)
    , paths              => lists:sort([bec_wz_path_t:from_map(P) || P <- FPR])
    , 'mandatory-users'  => lists:sort([bec_wz_user_t:from_map(U)
-                                        || U <- MUsers])
+                                       || U <- MUsers])
    , 'mandatory-groups' => lists:sort(MGroups)
    }.
 
@@ -55,6 +55,7 @@ to_map(#{ 'branch-id'             := BranchId
         } = Map) ->
   MUsers = maps:get('mandatory-users', Map, []),
   MGroups = maps:get('mandatory-groups', Map, []),
+  
   #{ <<"refName">>               => bec_wz_utils:add_prefix(BranchId)
    , <<"users">>                 => [bec_wz_user_t:to_map(U) || U <- Users]
    , <<"groups">>                => Groups

--- a/src/bec_wz_path_t.erl
+++ b/src/bec_wz_path_t.erl
@@ -16,6 +16,8 @@
 -type path() :: #{ path   := binary()
                  , users  := [bec_user_t:name()]
                  , groups := [bec_group_t:name()]
+                 , 'mandatory-users'  := [bec_wz_user_t:name()]
+                 , 'mandatory-groups' := [bec_group_t:name()]
                  }.
 
 %%==============================================================================
@@ -33,17 +35,28 @@ from_map(Map) ->
    , <<"users">>           := Users
    , <<"groups">>          := Groups
    } = Map,
+
+  MUsers = maps:get(<<"mandatoryUsers">>, Map, []),
+  MGroups = maps:get(<<"mandatoryGroups">>, Map, []),
+
   #{ path   => Path
    , users  => lists:sort([bec_wz_user_t:from_map(U) || U <- Users])
    , groups => lists:sort(Groups)
+   , 'mandatory-users' => lists:sort([bec_wz_user_t:from_map(U) || U <- MUsers])
+   , 'mandatory-groups' => lists:sort(MGroups)
    }.
 
 -spec to_map(path()) -> map().
 to_map(#{ path   := Path
         , users  := Users
         , groups := Groups
-        }) ->
+        } = Map) ->
+  MUsers = maps:get('mandatory-users', Map, []),
+  MGroups = maps:get('mandatory-groups', Map, []),
+
   #{ <<"filePathPattern">> => Path
    , <<"users">>           => [bec_wz_user_t:to_map(U) || U <- Users]
    , <<"groups">>          => Groups
+   , <<"mandatoryUsers">> => [bec_wz_user_t:to_map(U) || U <- MUsers]
+   , <<"mandatoryGroups">> => MGroups
    }.

--- a/src/bitbucket_http.erl
+++ b/src/bitbucket_http.erl
@@ -106,7 +106,8 @@ headers() ->
   Username = application:get_env(bec, bitbucket_username, ""),
   Password = application:get_env(bec, bitbucket_password, ""),
   Credentials = base64:encode_to_string(Username ++ ":" ++ Password),
-  [ {"Authorization", "Basic " ++ Credentials}
+  [
+    {"Authorization", "Basic " ++ Credentials}
   , {"Accept",        "application/json"}
   ].
 

--- a/test/bec_config_ss_SUITE.erl
+++ b/test/bec_config_ss_SUITE.erl
@@ -10,6 +10,7 @@
 %% Testcases
 -export([ to_wz_branch_reviewers_adds_default_mandatory/1 
         , to_wz_branch_reviewers_keeps_original_mandatory/1
+        , to_wz_branch_reviewers_adds_default_mandatory_in_path/1
         ]).
 
 %%==============================================================================
@@ -21,6 +22,7 @@
 all() ->
   [ to_wz_branch_reviewers_adds_default_mandatory
   , to_wz_branch_reviewers_keeps_original_mandatory
+  , to_wz_branch_reviewers_adds_default_mandatory_in_path
   ].
 
 to_wz_branch_reviewers_adds_default_mandatory(_Config) ->
@@ -59,6 +61,34 @@ to_wz_branch_reviewers_keeps_original_mandatory(_Config) ->
        , 'users'            => []
        , 'mandatory-users'  => [ <<"user.a">> ]
        , 'mandatory-groups' => [ <<"group.a">> ]
+       }
+      ],
+  ?assertEqual(ExpectedResult, bec_config_ss:to_wz_branch_reviewers(Reviewers)).
+
+to_wz_branch_reviewers_adds_default_mandatory_in_path(_Config) ->
+  Reviewers = 
+    [ #{ <<"branch-id">> => <<"master">>
+       , <<"groups">>    => []
+       , <<"paths">>     => [#{ <<"file-path-pattern">> => []
+                              , <<"users">> => []
+                              , <<"groups">> => []
+                            }]
+       , <<"users">>     => []
+       }
+    ],
+  ExpectedResult =
+    [ #{ 'branch-id'        => <<"master">>
+       , 'groups'           => []
+       , 'paths'            => [#{ 'file-path-pattern' => []
+                                 , 'users' => []
+                                 , 'groups' => []
+                                 , 'mandatory-users' => []
+                                 , 'mandatory-groups' => []
+                                }
+                               ]
+       , 'users'            => []
+       , 'mandatory-users'  => []
+       , 'mandatory-groups' => []
        }
       ],
   ?assertEqual(ExpectedResult, bec_config_ss:to_wz_branch_reviewers(Reviewers)).

--- a/test/bec_proper_gen.erl
+++ b/test/bec_proper_gen.erl
@@ -200,11 +200,13 @@ wz_branch_reviewer() ->
          }).
 
 wz_path() ->
-  ?LET( {Groups, Users, Path}
-      , {groupnames(), usernames(), path()}
+  ?LET( {Groups, Users, Path, MandatoryUsers, MandatoryGroups}
+      , {groupnames(), usernames(), path(), mandatory_users(), mandatory_groups()}
       , #{ groups => Groups
          , users  => Users
          , path   => Path
+         , 'mandatory-users'  => MandatoryUsers
+         , 'mandatory-groups' => MandatoryGroups
          }).
 
 path() ->

--- a/test/bitbucket_api_SUITE.erl
+++ b/test/bitbucket_api_SUITE.erl
@@ -108,10 +108,14 @@ get_wz_branch_reviewers(_Config) ->
        , paths       => [ #{ path => <<"lib/**">>
                            , users => [<<"user.b">>]
                            , groups => []
+                           , 'mandatory-users' => []
+                           , 'mandatory-groups' => []
                            }
                         , #{ path => <<"another_lib/**">>
                            , users =>  []
                            , groups => [<<"group.b">>]
+                           , 'mandatory-users' => []
+                           , 'mandatory-groups' => []
                            }
                         ]
        , 'mandatory-users' => []
@@ -137,10 +141,14 @@ get_wz_branch_reviewers_with_mandatory(_Config) ->
        , paths               => [ #{ path => <<"lib/**">>
                                    , users => [<<"user.b">>]
                                    , groups => []
+                                   , 'mandatory-users' => [<<"user.a">>]
+                                   , 'mandatory-groups' => []
                                    }
                                 , #{ path => <<"another_lib/**">>
                                    , users =>  []
                                    , groups => [<<"group.b">>]
+                                   , 'mandatory-users' => []
+                                   , 'mandatory-groups' => [<<"group.a">>]
                                    }
                                 ]
         , 'mandatory-users'  => [<<"user.a">>]

--- a/test/bitbucket_api_SUITE_data/get_wz_branch_reviewers_with_mandatory.json
+++ b/test/bitbucket_api_SUITE_data/get_wz_branch_reviewers_with_mandatory.json
@@ -31,7 +31,7 @@
           }
         ],
         "groups": [],
-        "mandatoryUsers": [],
+        "mandatoryUsers": [{"name": "user.a"}],
         "mandatoryGroups": []
       },
       {
@@ -42,7 +42,7 @@
           "group.b"
         ],
         "mandatoryUsers": [],
-        "mandatoryGroups": []
+        "mandatoryGroups": ["group.a"]
       }
     ]
   }


### PR DESCRIPTION
This will add the functionality to add mandatory `users` and/or `groups` to enforce review before able to merge. Please find the part of sample configuration below.

```yaml
wz-branch-reviewers:
  - branch-id: master
    users: []
    groups: []
    mandatory-users: [user1]
    mandatory-groups: [group1]
    paths:
      - path: path1/*
        users:
          - user2
          - user1
        groups: []
        mandatory-users: []
        mandatory-groups: [group1]
      - path: path2/*
        users:
          - user3
        groups: []
        mandatory-users: [user4, user1]
        mandatory-groups: []
```