### PR TITLE
Add supported to read YAML file

### DIFF
--- a/src/bitbucket_repo_config.erl
+++ b/src/bitbucket_repo_config.erl
@@ -15,6 +15,9 @@ verify(Path) ->
 -spec verify(string(), opts()) -> boolean().
 verify(Path, Options) ->
   case filename:extension(Path) of
+    ".yaml" ->
+      Config = read(Path),
+      do_verify(Options, Config);
     ".yml"  ->
       Config = read(Path),
       do_verify(Options, Config);


### PR DESCRIPTION
This is my personal propose idea that since we accept `yml` file and the content between `yaml` and `yml` is the same so we should accept the policy file with `.yaml` extension.