### PR TITLE
Add parameter ignore-self-approve for wz-pr-restrictions

### DIFF
--- a/sample_repo_configuration.yml
+++ b/sample_repo_configuration.yml
@@ -105,6 +105,7 @@ wz-pr-restrictions:
   - branch-id: develop
     approval-quota: 0 # The percentage of individuals reviewing a PR who must approve it before it can be merged
     group-quota: 1 # Minimum number of approvals required per group
+    ignore-self-approve: true # Pull request code contributor approvals are not counted towards quotas
 
 # Workzone Branch Reviewers
 wz-branch-reviewers:

--- a/src/bec_wz_pr_restriction_t.erl
+++ b/src/bec_wz_pr_restriction_t.erl
@@ -13,9 +13,10 @@
 %%==============================================================================
 %% Types
 %%==============================================================================
--type restriction() :: #{ 'branch-id'      := bec_branch_t:id()
-                        , 'approval-quota' := integer()
-                        , 'group-quota'    := integer()
+-type restriction() :: #{ 'branch-id'           := bec_branch_t:id()
+                        , 'approval-quota'      := integer()
+                        , 'group-quota'         := integer()
+                        , 'ignore-self-approve' := boolean()
                         }.
 
 %%==============================================================================
@@ -28,28 +29,33 @@
 %% API
 %%==============================================================================
 -spec from_map(map()) -> restriction().
-from_map(#{ <<"refName">>       := RefName
-          , <<"approvalQuota">> := ApprovalQuota
-          , <<"groupQuota">>    := GroupQuota
+from_map(#{ <<"refName">>                             := RefName
+          , <<"approvalQuota">>                       := ApprovalQuota
+          , <<"groupQuota">>                          := GroupQuota
+          , <<"ignoreContributingReviewersApproval">> := IgnoreSelfApprove
           }) ->
-  #{ 'branch-id'      => bec_wz_utils:strip_prefix(RefName)
-   , 'approval-quota' => binary_to_integer(ApprovalQuota)
-   , 'group-quota'    => GroupQuota
+  #{ 'branch-id'           => bec_wz_utils:strip_prefix(RefName)
+   , 'approval-quota'      => binary_to_integer(ApprovalQuota)
+   , 'group-quota'         => GroupQuota
+   , 'ignore-self-approve' => IgnoreSelfApprove
    }.
 
 -spec to_map(restriction()) -> map().
 to_map(#{ 'branch-id'      := BranchId
         , 'approval-quota' := ApprovalQuota
         , 'group-quota'    := GroupQuota
-        }) ->
-  #{ <<"approvalQuota">>           => ApprovalQuota
-   , <<"approvalQuotaEnabled">>    => true
-   , <<"automergeUsers">>          => []
-   , <<"deleteSourceBranch">>      => false
-   , <<"groupQuota">>              => GroupQuota
-   , <<"refName">>                 => bec_wz_utils:add_prefix(BranchId)
-   , <<"requiredBuildsCount">>     => <<>>
-   , <<"requiredSignaturesCount">> => <<>>
-   , <<"srcRefName">>              => <<>>
-   , <<"watchBuildResult">>        => false
+        } = Map) ->
+  IgnoreSelfApprove = maps:get('ignore-self-approve', Map, false),
+
+  #{ <<"approvalQuota">>                       => ApprovalQuota
+   , <<"approvalQuotaEnabled">>                => true
+   , <<"automergeUsers">>                      => []
+   , <<"deleteSourceBranch">>                  => false
+   , <<"groupQuota">>                          => GroupQuota
+   , <<"refName">> => bec_wz_utils:add_prefix(BranchId)
+   , <<"requiredBuildsCount">>                 => <<>>
+   , <<"requiredSignaturesCount">>             => <<>>
+   , <<"srcRefName">>                          => <<>>
+   , <<"watchBuildResult">>                    => false
+   , <<"ignoreContributingReviewersApproval">> => IgnoreSelfApprove
    }.

--- a/test/bec_proper_gen.erl
+++ b/test/bec_proper_gen.erl
@@ -175,11 +175,12 @@ wz_pr_restrictions() ->
   unique_list(wz_pr_restriction(), {map, 'branch-id'}).
 
 wz_pr_restriction() ->
-  ?LET( {BranchId, ApprovalQuota, GroupQuota}
-      , {branch_id(), non_zero_nat(), non_zero_nat()}
-      , #{ 'branch-id'      => BranchId
-         , 'approval-quota' => ApprovalQuota
-         , 'group-quota'    => GroupQuota
+  ?LET( {BranchId, ApprovalQuota, GroupQuota, IgnoreSelfApprove}
+      , {branch_id(), non_zero_nat(), non_zero_nat(), bool()}
+      , #{ 'branch-id'           => BranchId
+         , 'approval-quota'      => ApprovalQuota
+         , 'group-quota'         => GroupQuota
+         , 'ignore-self-approve' => IgnoreSelfApprove
          }).
 
 %%==============================================================================


### PR DESCRIPTION
The parameter controls following Workzone setting:
"Automatic Merge Configuration - Ignore committer approvals" ("ignoreContributingReviewersApproval" in API)