### PR TITLE
Add-default-value-for-wz-branch-reviewers

### DIFF
--- a/src/bec_wz_branch_reviewer_t.erl
+++ b/src/bec_wz_branch_reviewer_t.erl
@@ -49,13 +49,13 @@ from_map(#{ <<"refName">>           := RefName
 
 -spec to_map(reviewer()) -> map().
 to_map(#{ 'branch-id'             := BranchId
-        , users                   := Users
-        , groups                  := Groups
-        , paths                   := Paths
         } = Map) ->
   MUsers = maps:get('mandatory-users', Map, []),
   MGroups = maps:get('mandatory-groups', Map, []),
-  
+  Users = maps:get('users', Map, []),
+  Groups = maps:get('groups', Map, []),
+  Paths = maps:get('paths', Map, []),
+
   #{ <<"refName">>               => bec_wz_utils:add_prefix(BranchId)
    , <<"users">>                 => [bec_wz_user_t:to_map(U) || U <- Users]
    , <<"groups">>                => Groups


### PR DESCRIPTION
This will make the configuration value optional excepted the branch-id which will be mandatory.