### PR TITLE
bitbucket_repo_config:do_verify/4: do not io:format details on mismat…

### DIFF
--- a/src/bitbucket_repo_config.erl
+++ b/src/bitbucket_repo_config.erl
@@ -170,11 +170,11 @@ do_verify(ProjectKey, RepoSlug, Key, Expected) ->
     true ->
       true;
     false ->
-      %% How to pretty-format these messages with lager?
-      ok = io:format( "[~s/~s] Actual   ==> ~p ~n"
-                    , [ProjectKey, RepoSlug, Actual]),
-      ok = io:format( "[~s/~s] Expected ==> ~p ~n"
-                    , [ProjectKey, RepoSlug, Adapted]),
+      %% Not showing details here since they may contain secrets.
+      %% They were debug-logged above.
+      ok = lager:error( "[~s/~s] Actual does not match Expected"
+                        " (increase verbosity to see details)~n"
+                      , [ProjectKey, RepoSlug]),
       false
   end.
 


### PR DESCRIPTION
…ch to avoid leaking secrets

We had issues with the `io:format` calls logging secrets to Jenkins logs which were available to a larger audience than those with access to the secrets.