### PR TITLE
Added delay parameter to throttle trying each repo_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2022-06-17
+
+- Added delay parameter to throttle trying each repo_config
+
 ## [1.0.0] - 2020-08-16
 
 - Open sourcing of an existing internal project

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Usage: bec [-h] [-c [<config>]] [-r [<repo_config>]]
   -h, --help         Show this help message
   -c, --config       The BitBucket Config File [default: bitbucket.config]
   -r, --repo_config  The Repo Config to check or configure [default: undefined]
+  -d, --delay        Delay (in seconds) between trying each repo_config  
   -e, --enforce      Enforce values when they do not match expectations [default: false]
   -k, --keep         Keep going after the first error (always true when enforce == true) [default: false]
   -v, --verbosity    Verbosity Level [default: 1]

--- a/src/bec.erl
+++ b/src/bec.erl
@@ -39,8 +39,10 @@ do_main(Options) ->
                 RepoConfig ->
                     Enforce = proplists:get_value(enforce, Options),
                     K       = proplists:get_value(keep, Options),
+                    Delay   = proplists:get_value(delay, Options),
                     case bitbucket_repo_config:verify( RepoConfig,
                                                        [ {enforce, Enforce}
+                                                       , {delay, Delay}
                                                        , {abort_on_error, not K}
                                                        ]) of
                         true ->
@@ -70,6 +72,8 @@ specs() ->
       , "The BitBucket Config File"}
     , { repo_config, $r, "repo_config", {string, undefined}
       , "The Repo Config to check or configure"}
+    , { delay,       $d, "delay",       {integer, 0}
+      , "Delay (in seconds) between trying each repo_config"}
     , { enforce,     $e, "enforce",     {boolean, false}
       , "Enforce values when they do not match expectations"}
     , { keep,        $k, "keep",        {boolean, false}

--- a/src/bitbucket_repo_config.erl
+++ b/src/bitbucket_repo_config.erl
@@ -25,10 +25,14 @@ verify(Path, Options) ->
       Dirname  = filename:dirname(Path),
       Basename = filename:basename(Path, ".ymlt"),
       VarsPath = filename:join([Dirname, Basename ++ ".ymlv"]),
+      %% Convert Delay to milliseconds
+      Delay    = proplists:get_value(delay, Options, 0) * 1000,
       Vars = read_vars(VarsPath),
       All = [begin
                [Config] = read_template(Path, Var),
-               do_verify(Options, Config)
+               Result = do_verify(Options, Config),
+               timer:sleep(Delay),
+               Result
              end || Var <- Vars],
       lists:all(fun(true) -> true; (false) -> false end, All);
     Ext ->


### PR DESCRIPTION
I added a new parameter "delay" that is meant to throttle trying each different repo when using .ymlt and .ymlv files. If bitbucket responds with "429 Too Many Requests" frequently then this option can be used to slow down trying against bitbucket and hopefully not run into the 429 status code problem