### PR TITLE
Update test case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2022-07-06
+
+- Made merge-condition optional in wz pr restrictions from_map/1 conversion. 
+- Added test data for merge-condition for wz pr restrictions data generation.
+
 ## [1.1.0] - 2022-06-17
 
 - Added delay parameter to throttle trying each repo_config

--- a/src/bec_wz_pr_restriction_t.erl
+++ b/src/bec_wz_pr_restriction_t.erl
@@ -34,8 +34,8 @@ from_map(#{ <<"refName">>                             := RefName
           , <<"approvalQuota">>                       := ApprovalQuota
           , <<"groupQuota">>                          := GroupQuota
           , <<"ignoreContributingReviewersApproval">> := IgnoreSelfApprove
-          , <<"mergeCondition">>                      := MergeCondition
-          }) ->
+          } = Map) ->
+  MergeCondition = maps:get(<<"mergeCondition">>, Map, <<"">>),
   #{ 'branch-id'           => bec_wz_utils:strip_prefix(RefName)
    , 'approval-quota'      => binary_to_integer(ApprovalQuota)
    , 'group-quota'         => GroupQuota

--- a/src/bec_wz_pr_restriction_t.erl
+++ b/src/bec_wz_pr_restriction_t.erl
@@ -44,19 +44,19 @@ from_map(#{ <<"refName">>                             := RefName
    }.
 
 -spec to_map(restriction()) -> map().
-to_map(#{ 'branch-id'      := BranchId
-        } = Map) ->
-  ApprovalQuota = maps:get('approval-quota', Map, 0),
-  GroupQuota = maps:get('group-quota', Map, 0),
-  MergeCondition = maps:get('merge-condition', Map, ""),
+to_map(#{ 'branch-id' := BranchId } = Map) ->
+  ApprovalQuota     = maps:get('approval-quota', Map, 0),
+  GroupQuota        = maps:get('group-quota', Map, 0),
+  MergeCondition    = maps:get('merge-condition', Map, ""),
   IgnoreSelfApprove = maps:get('ignore-self-approve', Map, false),
+  RefName           = bec_wz_utils:add_prefix(BranchId),
   #{ <<"approvalQuota">>                       => ApprovalQuota
    , <<"approvalQuotaEnabled">>                => true
    , <<"automergeUsers">>                      => []
    , <<"deleteSourceBranch">>                  => false
    , <<"groupQuota">>                          => GroupQuota
    , <<"mergeCondition">>                      => MergeCondition
-   , <<"refName">> => bec_wz_utils:add_prefix(BranchId)
+   , <<"refName">>                             => RefName
    , <<"requiredBuildsCount">>                 => <<>>
    , <<"requiredSignaturesCount">>             => <<>>
    , <<"srcRefName">>                          => <<>>

--- a/test/bec_proper_gen.erl
+++ b/test/bec_proper_gen.erl
@@ -176,7 +176,7 @@ wz_pr_restrictions() ->
 
 wz_pr_restriction() ->
   ?LET( {BranchId, ApprovalQuota, GroupQuota, IgnoreSelfApprove, MergeCondition}
-      , {branch_id(), non_zero_nat(), non_zero_nat(), bool(), binary()}
+      , {branch_id(), non_zero_nat(), non_zero_nat(), bool(), merge_condition()}
       , #{ 'branch-id'           => BranchId
          , 'approval-quota'      => ApprovalQuota
          , 'group-quota'         => GroupQuota
@@ -324,6 +324,9 @@ webhook() ->
 
 webhooks() ->
   unique_list(webhook(), {map, 'name'}).
+
+merge_condition() ->
+  oneof([<<"">>, <<"approvalCount > 1 & groupQuota >= 1">>]).
 
 %%==============================================================================
 %% Helpers


### PR DESCRIPTION
Made 'merge-condition' be optional. It will not always be present when fetching settings from bitbucket so it needs to be optional.
Added proper data for merge-condition for wz pr restrictions data generation.

Some small indentation fixes.