### PR TITLE
Updated changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.1] - 2022-07-06
+## [1.3.0] - 2022-07-06
 
 - Made merge-condition optional in wz pr restrictions from_map/1 conversion. 
 - Added test data for merge-condition for wz pr restrictions data generation.
-
-## [1.1.0] - 2022-06-17
-
 - Added delay parameter to throttle trying each repo_config
 
 ## [1.0.0] - 2020-08-16


### PR DESCRIPTION
The changelog had not been updated despite tags being created. I added 1.3.0 in the changelog, but ignored 1.1.0 and 1.2.0 because I do not know what those versions contains.