### PR TITLE
Bump OTP versions to [23, 24, 25]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        otp-version: [21.3, 22.2, 23.0]
+        otp-version: [23, 24, 25]
     runs-on: ${{ matrix.platform }}
     container:
       image: erlang:${{ matrix.otp-version }}


### PR DESCRIPTION
This makes BEC require OTP 23, which is the oldest OTP version currently supported.
