### PR TITLE
50 run tests requiring a bitbucket server in GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
           SETUP_SYSADMIN_DISPLAYNAME: Admin
           SETUP_SYSADMIN_EMAILADDRESS: admin@example.com
           SEARCH_ENABLED: false
-        options: --health-cmd "curl -s http://localhost:7990/status | grep RUNNING"
+        options: --health-retries 20 --health-cmd "curl -s http://localhost:7990/status | grep RUNNING"
 
     steps:
     - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,27 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        otp-version: [23, 24, 25]
+        otp-version: [25]
     runs-on: ${{ matrix.platform }}
     container:
       image: erlang:${{ matrix.otp-version }}
+    services:
+      bitbucket:
+        image: atlassian/bitbucket-server:7.17.1
+        ports:
+          - 7990:7990
+        env:
+          SETUP_DISPLAYNAME: Bitbucket
+          SETUP_BASEURL: http://bitbucket:7990
+          # Get license here https://developer.atlassian.com/platform/marketplace/timebomb-licenses-for-testing-server-apps/
+          SETUP_LICENSE: AAABrQ0ODAoPeNp9kVFvmzAQx9/9KSztLZIJZIu0RkJqA6yNViAK0G3d+uDApXgjNrKPbPn2dYG0a 6fuwS8+393v//O7vAMa8yN1PerOFrPZYn5GL+OczlzvI0m6/RZ0uisMaON7LgmURF5iwvfgVy3XW pj6nGPDjRFcOqXaE4Pc1M61KEEayI8t9I+DNI6jTbC6uP73wd/FdafLmhsIOYL/yMDcOXM98p95Y yn60wp97PvW769OpFHMRfMWagb6AHoV+svLs5x9LW4+sM+3t1ds6XpfRkw7jwcgEbSPugOSdVtTa tGiUHK4mUwmSZqzT+mGrTdpWAT5Kk1YkUW24AcaLFBFt0eKNdARlUayVBVo2mr1E0qk32vE9sdiO r1XzgvEaTN0MBg67hwaKioV0koY1GLbIdjJwlBUtOwMqr39KYfY1JZZclm+9jLEsmbEAZ4CBJvoI o9Ctvz2CP2GrRHe6irkL6l+S5JFiW8Pm7suSfU9l8LwXkwIB2hUaxPmYPAUm/Q2bP315w5MGXL95 DmEZ839jFEE3SlNedvS6rTCkOjAm25YvOON3fMAVTj4nTAtAhRH4o+fI5MQ7xSh2mtA1bPJrq0WA gIVAIGperR8m2N0fl/GfUUJfQnd+T1aX02kk
+          SETUP_SYSADMIN_USERNAME: admin
+          SETUP_SYSADMIN_PASSWORD: admin
+          SETUP_SYSADMIN_DISPLAYNAME: Admin
+          SETUP_SYSADMIN_EMAILADDRESS: admin@example.com
+          SEARCH_ENABLED: false
+        options: --health-cmd "curl -s http://localhost:7990/status | grep RUNNING"
+
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -34,8 +51,25 @@ jobs:
           ${{ runner.os }}-dialyzer-
     - name: Compile
       run: rebar3 as test compile
-    - name: Dialyzer
-      run: rebar3 dialyzer
+    - name: Run PropEr Tests
+      run: rebar3 proper
+      env:
+        BB_STAGING_URL: http://bitbucket:7990
+        BB_STAGING_PROJECT_KEY: TOOLS
+        BB_STAGING_REPO_SLUG: bec-test
+        BB_STAGING_GROUP_A: group.a
+        BB_STAGING_GROUP_B: group.b
+        BB_STAGING_USER_A: user.a
+        BB_STAGING_USER_B: user.b
+        BB_STAGING_USERNAME: admin
+        BB_STAGING_PASSWORD: admin
+    - name: Store logs from PropEr runs
+      uses: actions/upload-artifact@v3
+      with:
+        name: proper-logs
+        path: log/*.log
+    - name: Run Checks
+      run: rebar3 do dialyzer,xref
     - name: Run EUnit Tests
       run: rebar3 eunit
     - name: Run CT Tests
@@ -45,8 +79,6 @@ jobs:
       with:
         name: ct-logs
         path: _build/test/logs
-    - name: Run Checks
-      run: rebar3 do dialyzer, xref
     - name: Create Cover Reports
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,8 +57,8 @@ jobs:
         BB_STAGING_URL: http://bitbucket:7990
         BB_STAGING_PROJECT_KEY: TOOLS
         BB_STAGING_REPO_SLUG: bec-test
-        BB_STAGING_GROUP_A: group.a
-        BB_STAGING_GROUP_B: group.b
+        BB_STAGING_TEAM_A: team.a
+        BB_STAGING_TEAM_B: team.b
         BB_STAGING_USER_A: user.a
         BB_STAGING_USER_B: user.b
         BB_STAGING_USERNAME: admin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        otp-version: [25]
+        otp-version: [23, 24, 25]
     runs-on: ${{ matrix.platform }}
     container:
       image: erlang:${{ matrix.otp-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,17 @@ jobs:
           ${{ runner.os }}-dialyzer-
     - name: Compile
       run: rebar3 as test compile
+    - name: Run Checks
+      run: rebar3 do dialyzer,xref
+    - name: Run EUnit Tests
+      run: rebar3 eunit
+    - name: Run CT Tests
+      run: rebar3 ct
+    - name: Store CT Logs
+      uses: actions/upload-artifact@v1
+      with:
+        name: ct-logs
+        path: _build/test/logs
     - name: Run PropEr Tests
       run: rebar3 proper
       env:
@@ -68,17 +79,6 @@ jobs:
       with:
         name: proper-logs
         path: log/*.log
-    - name: Run Checks
-      run: rebar3 do dialyzer,xref
-    - name: Run EUnit Tests
-      run: rebar3 eunit
-    - name: Run CT Tests
-      run: rebar3 ct
-    - name: Store CT Logs
-      uses: actions/upload-artifact@v1
-      with:
-        name: ct-logs
-        path: _build/test/logs
     - name: Create Cover Reports
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -173,6 +173,16 @@ repo:
   currently supported
 * The BitBucket Paged API is not supported, yet
 
+## Running tests against Bitbucket
+
+The full test suite (including PropEr tests) needs a Bitbucket Server
+instance to run.  Running "rebar3 proper" will check if there is one
+already running on http://localhost:7990 and start one using a docker
+container if no one is found.
+
+This functionality requires
+[docker-compose](https://docs.docker.com/compose/).
+
 ## Author
 
 * Roberto Aloi

--- a/include/bitbucket.hrl
+++ b/include/bitbucket.hrl
@@ -4,3 +4,6 @@
 -type project_key()      :: binary().
 -type repo_slug()        :: binary().
 -type branch_id()        :: binary().
+-type group()            :: binary().
+-type user()             :: binary().
+-type email()            :: binary().

--- a/rebar.config
+++ b/rebar.config
@@ -21,6 +21,10 @@
            , {warnings, [unknown]}
            ]}.
 
+%% The pre/post test hooks will setup a local bitbucket instance to
+%% test against This has only been verified to work on Linux.
+{pre_hooks, [{"linux", proper, "scripts/pre-test-hook.sh"}]}.
+
 {profiles     , [ {prod, [ {relx, [ {dev_mode, false}, {include_erts, true}]}]}
                 , {test, [ { erl_opts, [ nowarn_export_all
                                        , nowarn_missing_spec_all

--- a/run-tests-with-bb.sh
+++ b/run-tests-with-bb.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+export BB_STAGING_URL=http://localhost:7990
+export BB_STAGING_PROJECT_KEY=TOOLS
+export BB_STAGING_REPO_SLUG=bec-test
+export BB_STAGING_TEAM_A=team.a
+export BB_STAGING_TEAM_B=team.b
+export BB_STAGING_USER_A=user.a
+export BB_STAGING_USER_B=user.b
+export BB_STAGING_USERNAME=admin
+export BB_STAGING_PASSWORD=admin
+
+rebar3 proper

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -1,0 +1,30 @@
+version: '2'
+
+services:
+  bitbucket:
+    image: atlassian/bitbucket-server:7.17.1
+    restart: always
+    networks:
+      - bridge
+    ports:
+      - '7990:7990'
+    environment:
+      - 'SETUP_DISPLAYNAME=Bitbucket'
+      - 'SETUP_BASEURL=http://localhost:7990'
+      # Get license here https://developer.atlassian.com/platform/marketplace/timebomb-licenses-for-testing-server-apps/
+      - 'SETUP_LICENSE=AAABrQ0ODAoPeNp9kVFvmzAQx9/9KSztLZIJZIu0RkJqA6yNViAK0G3d+uDApXgjNrKPbPn2dYG0a 6fuwS8+393v//O7vAMa8yN1PerOFrPZYn5GL+OczlzvI0m6/RZ0uisMaON7LgmURF5iwvfgVy3XW pj6nGPDjRFcOqXaE4Pc1M61KEEayI8t9I+DNI6jTbC6uP73wd/FdafLmhsIOYL/yMDcOXM98p95Y yn60wp97PvW769OpFHMRfMWagb6AHoV+svLs5x9LW4+sM+3t1ds6XpfRkw7jwcgEbSPugOSdVtTa tGiUHK4mUwmSZqzT+mGrTdpWAT5Kk1YkUW24AcaLFBFt0eKNdARlUayVBVo2mr1E0qk32vE9sdiO r1XzgvEaTN0MBg67hwaKioV0koY1GLbIdjJwlBUtOwMqr39KYfY1JZZclm+9jLEsmbEAZ4CBJvoI o9Ctvz2CP2GrRHe6irkL6l+S5JFiW8Pm7suSfU9l8LwXkwIB2hUaxPmYPAUm/Q2bP315w5MGXL95 DmEZ839jFEE3SlNedvS6rTCkOjAm25YvOON3fMAVTj4nTAtAhRH4o+fI5MQ7xSh2mtA1bPJrq0WA gIVAIGperR8m2N0fl/GfUUJfQnd+T1aX02kk'
+      - 'SETUP_SYSADMIN_USERNAME=admin'
+      - 'SETUP_SYSADMIN_PASSWORD=admin'
+      - 'SETUP_SYSADMIN_DISPLAYNAME=Admin'
+      - 'SETUP_SYSADMIN_EMAILADDRESS=admin@example.com'
+      - 'SEARCH_ENABLED=false'
+    healthcheck:
+      test: ['CMD', 'bash', '-c', 'curl -s http://localhost:7990/status | grep RUNNING']
+      interval: 5s
+      start_period: 10s
+      retries: 10
+    mem_limit: 4G
+
+networks:
+  bridge:
+    driver: bridge

--- a/scripts/pre-test-hook.sh
+++ b/scripts/pre-test-hook.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+BB_STAGING_URL=${BB_STAGING_URL:-http://localhost:7990}
+
+set -e
+
+if curl -s "$BB_STAGING_URL/status" | grep -q RUNNING ; then
+    echo "Bitbucket server at $BB_STAGING_URL is up"
+else
+    if docker-compose version >/dev/null 2>&1; then
+        echo "Bitbucket server at $BB_STAGING_URL does not seem to be up, starting local instance..."
+        SCRIPTS_DIR=$(cd "$(dirname "$0")" || exit 1; pwd)
+        (cd "$SCRIPTS_DIR" && docker-compose up --build -d --wait)
+        echo "You can leave this Bitbucket server running until you are done testing."
+        echo "To stop this instance, run 'docker-compose down' in the scripts directory."
+    else
+        echo "No Bitbucket server found at $BB_STAGING_URL, and docker-compose is not installed."
+        echo "Refer to README.md for instructions."
+        exit 1
+    fi
+fi

--- a/src/bitbucket.erl
+++ b/src/bitbucket.erl
@@ -56,6 +56,19 @@
           %% Webhooks
         , get_webhooks/2
         , set_webhooks/3
+
+          %% Setting up projects/repos/users, currently only used
+          %% for testing
+        , create_project/1
+        , delete_project/1
+        , create_repo/2
+        , delete_repo/2
+        , create_group/1
+        , remove_group/1
+        , create_user/4
+        , remove_user/1
+        , create_branch/4
+        , add_user_to_groups/2
         ]).
 
 %%==============================================================================
@@ -551,4 +564,75 @@ set_webhooks(ProjectKey, RepoSlug, WebHooks) ->
     #{id := Id} <- OldWebHooks],
   [{ok, _} = bitbucket_api:set_webhook(ProjectKey, RepoSlug, WebHook) ||
     WebHook <- WebHooks],
+  ok.
+
+%%==============================================================================
+%% Testing
+%%==============================================================================
+-spec create_project(Key :: project_key()) -> ok.
+create_project(Key) ->
+  {ok, _} = bitbucket_api:create_project(#{<<"key">> => Key}),
+  ok.
+
+-spec delete_project(Key :: project_key()) -> ok.
+delete_project(Key) ->
+  {ok, _} = bitbucket_api:delete_project(Key),
+  ok.
+
+-spec create_repo(Key :: project_key(), RepoSlug :: repo_slug()) -> ok.
+create_repo(Key, RepoSlug) ->
+  {ok, _} = bitbucket_api:create_repo(Key, #{<<"slug">> => RepoSlug,
+                                             <<"name">> => RepoSlug,
+                                             <<"scmId">> => <<"git">>}),
+  ok.
+
+-spec delete_repo(Key :: project_key(), RepoSlug :: repo_slug()) -> ok.
+delete_repo(Key, RepoSlug) ->
+  {ok, _} = bitbucket_api:delete_repo(Key, RepoSlug),
+  ok.
+
+-spec create_group(Group :: group()) -> ok.
+create_group(Group) ->
+  {ok, _} = bitbucket_api:create_group(Group),
+  ok.
+
+-spec remove_group(Group :: group()) -> ok.
+remove_group(Group) ->
+  {ok, _} = bitbucket_api:remove_group(Group),
+  ok.
+
+-spec create_user(UserName :: user(),
+                  UserEmail :: email(),
+                  UserDisplayName :: binary(),
+                  Password :: binary()) ->
+        ok.
+create_user(UserName, UserEmail, UserDisplayName, Password) ->
+  {ok, _} = bitbucket_api:create_user(UserName,
+                                      UserEmail,
+                                      UserDisplayName,
+                                      Password),
+  ok.
+
+-spec remove_user(UserName :: user()) -> ok.
+remove_user(UserName) ->
+  {ok, _} = bitbucket_api:remove_user(UserName),
+  ok.
+
+-spec create_branch(ProjectKey :: project_key(),
+                    RepoSlug :: repo_slug(),
+                    BranchName :: branch_id(),
+                    StartPoint :: branch_id()) ->
+        ok.
+create_branch(ProjectKey, RepoSlug, BranchName, StartPoint) ->
+  {ok, _} = bitbucket_api:create_branch(ProjectKey, RepoSlug,
+                                       #{<<"name">> => BranchName,
+                                         <<"startPoint">> => StartPoint}),
+  ok.
+
+-spec add_user_to_groups(User :: user(),
+                        Groups :: [group()]) ->
+        ok.
+add_user_to_groups(User, Groups) ->
+  {ok, _} = bitbucket_api:add_user_to_groups(#{<<"user">> => User,
+                                               <<"groups">> => Groups}),
   ok.

--- a/src/bitbucket_api.erl
+++ b/src/bitbucket_api.erl
@@ -53,6 +53,18 @@
         , delete_webhook/3
         , get_webhooks/2
         , set_webhook/3
+
+          %% For testing
+        , create_project/1
+        , delete_project/1
+        , create_repo/2
+        , delete_repo/2
+        , create_group/1
+        , remove_group/1
+        , create_user/4
+        , remove_user/1
+        , create_branch/3
+        , add_user_to_groups/1
         ]).
 
 -include("bitbucket.hrl").
@@ -405,6 +417,102 @@ set_webhook(ProjectKey, RepoSlug, Map) ->
   Args  = [?API_VSN, ProjectKey, RepoSlug],
   Url   = format_url(Fmt, Args),
   bitbucket_http:post_request(Url, jsx:encode(Map)).
+
+%%==============================================================================
+%% Tests
+%%==============================================================================
+-spec create_project(Map :: map()) ->
+        {ok, map()} | {error, map()}.
+create_project(Map) ->
+  Fmt   = "/rest/api/~s/projects",
+  Args  = [?API_VSN],
+  Url   = format_url(Fmt, Args),
+  bitbucket_http:post_request(Url, jsx:encode(Map)).
+
+-spec delete_project(Key :: project_key()) ->
+        {ok, map()} | {error, map()}.
+delete_project(Key) ->
+  Fmt   = "/rest/api/~s/projects/~s",
+  Args  = [?API_VSN, Key],
+  Url   = format_url(Fmt, Args),
+  bitbucket_http:delete_request(Url).
+
+-spec create_repo(Key :: project_key(),
+                  Map :: map()) ->
+        {ok, map()} | {error, map()}.
+create_repo(Key, Map) ->
+  Fmt   = "/rest/api/~s/projects/~s/repos",
+  Args  = [?API_VSN, Key],
+  Url   = format_url(Fmt, Args),
+  bitbucket_http:post_request(Url, jsx:encode(Map)).
+
+-spec delete_repo(Key :: project_key(),
+                  RepoSlug :: repo_slug()) ->
+        {ok, map()} | {error, map()}.
+delete_repo(Key, RepoSlug) ->
+  Fmt   = "/rest/api/~s/projects/~s/repos/~s",
+  Args  = [?API_VSN, Key, RepoSlug],
+  Url   = format_url(Fmt, Args),
+  bitbucket_http:delete_request(Url).
+
+-spec create_group(Group :: group()) ->
+        {ok, map()} | {error, map()}.
+create_group(Group) ->
+  Fmt   = "/rest/api/~s/admin/groups?name=~s",
+  Args  = [?API_VSN, Group],
+  Url   = format_url(Fmt, Args),
+  bitbucket_http:post_request(Url, jsx:encode(#{})).
+
+-spec remove_group(Group :: group()) ->
+        {ok, map()} | {error, map()}.
+remove_group(Group) ->
+  Fmt   = "/rest/api/~s/admin/groups?name=~s",
+  Args  = [?API_VSN, Group],
+  Url   = format_url(Fmt, Args),
+  bitbucket_http:delete_request(Url, jsx:encode(#{})).
+
+-spec create_user(UserName :: user(),
+                  UserEmail :: email(),
+                  UserDisplayName :: binary(),
+                  Password :: binary()) ->
+        {ok, map()} | {error, map()}.
+create_user(UserName, UserEmail, UserDisplayName, Password) ->
+  Fmt   = "/rest/api/~s/admin/users?~s",
+  Args  = [?API_VSN,
+           uri_string:compose_query([ {"emailAddress", UserEmail}
+                                    , {"displayName", UserDisplayName}
+                                    , {"name", UserName}
+                                    , {"password", Password}
+                                    ])],
+  Url   = format_url(Fmt, Args),
+  bitbucket_http:post_request(Url, jsx:encode(#{})).
+
+-spec remove_user(UserName :: user()) ->
+        {ok, map()} | {error, map()}.
+remove_user(UserName) ->
+  Fmt   = "/rest/api/~s/admin/users?name=~s",
+  Args  = [?API_VSN, UserName],
+  Url   = format_url(Fmt, Args),
+  bitbucket_http:delete_request(Url, jsx:encode(#{})).
+
+-spec create_branch(ProjectKey :: project_key(),
+                    RepoSlug :: repo_slug(),
+                    Map :: map()) ->
+        {ok, map()} | {error, map()}.
+create_branch(ProjectKey, RepoSlug, Map) ->
+  Fmt   = "/rest/api/~s/projects/~s/repos/~s/branches",
+  Args  = [?API_VSN, ProjectKey, RepoSlug],
+  Url   = format_url(Fmt, Args),
+  bitbucket_http:post_request(Url, jsx:encode(Map)).
+
+-spec add_user_to_groups(Map :: map()) ->
+        {ok, map()} | {error, map()}.
+add_user_to_groups(Map) ->
+  Fmt   = "/rest/api/~s/admin/users/add-groups",
+  Args  = [?API_VSN],
+  Url   = format_url(Fmt, Args),
+  bitbucket_http:post_request(Url, jsx:encode(Map)).
+
 
 %%==============================================================================
 %% Internal Functions

--- a/src/bitbucket_http.erl
+++ b/src/bitbucket_http.erl
@@ -117,6 +117,7 @@ authorization() ->
         {ok, map()} | {ok, [map()]} | {error, any()}.
 handle_result({ok, {{_Ver, Status, _Phrase}, _H, Body}}) when Status =:= 200;
                                                               Status =:= 201;
+                                                              Status =:= 202;
                                                               Status =:= 204 ->
   {ok, decode_body(Body)};
 handle_result({ok, {{_Version, _Status, _Phrase}, _Headers, Resp}}) ->

--- a/test/bec_test_utils.erl
+++ b/test/bec_test_utils.erl
@@ -1,0 +1,111 @@
+%% Test utilities for setting up a Bitbucket instance for test purposes.
+-module(bec_test_utils).
+
+-export([ init_bitbucket/0
+        , deinit_bitbucket/0
+        , init_logging/0
+        ]).
+
+-compile([{parse_transform, lager_transform}]).
+
+cmd(Fmt, Args) ->
+  Cmd = lists:flatten(io_lib:format(Fmt, Args)),
+  %%io:format("Command: ~p~n", [Cmd]),
+  _Result = os:cmd(Cmd),
+  %%io:format("Command output: ~s~n", [Result]),
+  ok.
+
+init_repo() ->
+  Url           = os:getenv("BB_STAGING_URL", "http://localhost"),
+  Username      = os:getenv("BB_STAGING_USERNAME", ""),
+  Password      = os:getenv("BB_STAGING_PASSWORD", ""),
+
+  Map = uri_string:parse(Url),
+
+  ProjectKey = os:getenv("BB_STAGING_PROJECT_KEY", ""),
+  RepoSlug = os:getenv("BB_STAGING_REPO_SLUG", ""),
+
+  %% TODO see if we can get this url through the REST api instead of
+  %% reconstructing it from the Bitbucket Server url.
+  GitUrl = io_lib:format("~s://~s:~s@~s:~w/scm/~s/~s.git",
+                         [maps:get(scheme, Map),
+                          Username,
+                          Password,
+                          maps:get(host, Map),
+                          maps:get(port, Map),
+                          ProjectKey,
+                          RepoSlug]),
+
+  LocalRepo = "/tmp/bec-test" ++ integer_to_list(rand:uniform(1 bsl 127)),
+  ok = cmd("mkdir -p ~s && cd ~s && "
+           "git init . && "
+           "git config user.email $USER@$HOSTNAME && "
+           "git config user.name Anonymous && "
+           "echo >README.md && git add README.md && "
+           "git commit -a -m 'First commit' && "
+           "git remote add origin ~s && git fetch && "
+           "git push origin master && "
+           "rm -rf ~s",
+           [LocalRepo, LocalRepo, GitUrl, LocalRepo]),
+
+  ok = bitbucket:set_default_branch(ProjectKey, RepoSlug, <<"master">>),
+  ok = bitbucket:create_branch(ProjectKey, RepoSlug, <<"feature">>, <<"master">>).
+
+init_bitbucket() ->
+  ProjectKey = list_to_binary(os:getenv("BB_STAGING_PROJECT_KEY", "")),
+  RepoSlug = list_to_binary(os:getenv("BB_STAGING_REPO_SLUG", "")),
+  TeamA = list_to_binary(os:getenv("BB_STAGING_TEAM_A", "team.a")),
+  TeamB = list_to_binary(os:getenv("BB_STAGING_TEAM_B", "team.b")),
+
+  UserA = list_to_binary(os:getenv("BB_STAGING_USER_A", "user.a")),
+  UserEmailA = list_to_binary(os:getenv("BB_STAGING_USER_A", "user.a") ++ "@email.com"),
+  UserDisplayNameA = list_to_binary(os:getenv("BB_STAGING_USER_A", "user.a") ++ " (Name)"),
+
+  UserB = list_to_binary(os:getenv("BB_STAGING_USER_B", "user.b")),
+  UserEmailB = list_to_binary(os:getenv("BB_STAGING_USER_B", "user.b") ++ "@email.com"),
+  UserDisplayNameB = list_to_binary(os:getenv("BB_STAGING_USER_B", "user.b") ++ " (Name)"),
+
+  deinit_bitbucket(),
+
+  try
+    ok = bitbucket:create_project(ProjectKey),
+    ok = bitbucket:create_repo(ProjectKey, RepoSlug),
+    ok = bitbucket:create_group(TeamA),
+    ok = bitbucket:create_group(TeamB),
+    ok = bitbucket:create_user(UserA, UserEmailA, UserDisplayNameA, <<"password">>),
+    ok = bitbucket:create_user(UserB, UserEmailB, UserDisplayNameB, <<"password">>),
+    ok = bitbucket:add_user_to_groups(UserA, [TeamA]),
+    ok = bitbucket:add_user_to_groups(UserB, [TeamB]),
+    init_repo()
+  catch C:T:St ->
+      %% If the setup function fails, the teardown function is not
+      %% executed and we risk leaving a running bitbucket instance in a
+      %% inconsistent state.
+      deinit_bitbucket(),
+      io:format("Caught exception in setup:~n~p~n", [{C,T,St}]),
+      throw(T)
+  end.
+
+deinit_bitbucket() ->
+  ProjectKey = list_to_binary(os:getenv("BB_STAGING_PROJECT_KEY", "")),
+  RepoSlug = list_to_binary(os:getenv("BB_STAGING_REPO_SLUG", "")),
+  TeamA = list_to_binary(os:getenv("BB_STAGING_TEAM_A", "team.a")),
+  TeamB = list_to_binary(os:getenv("BB_STAGING_TEAM_B", "team.b")),
+  UserA = list_to_binary(os:getenv("BB_STAGING_USER_A", "user.a")),
+  UserB = list_to_binary(os:getenv("BB_STAGING_USER_B", "user.b")),
+
+  %% Try as best as possible to cleanup the bitbucket instance, and
+  %% don't fail if e.g. some user doesn't exist.
+  catch bitbucket:remove_user(UserA),
+  catch bitbucket:remove_user(UserB),
+  catch bitbucket:remove_group(TeamA),
+  catch bitbucket:remove_group(TeamB),
+  catch bitbucket:delete_repo(ProjectKey, RepoSlug),
+  catch bitbucket:delete_project(ProjectKey).
+
+init_logging() ->
+  lager:start(),
+  lager:set_loglevel(lager_file_backend, debug),
+  lager:set_loglevel(lager_console_backend, none),
+  %% io:format("Lager config:~n~s~n", [lager:status()]).
+  ok.

--- a/test/bec_test_utils.erl
+++ b/test/bec_test_utils.erl
@@ -4,6 +4,7 @@
 -export([ init_bitbucket/0
         , deinit_bitbucket/0
         , init_logging/0
+        , is_wz_supported/0
         ]).
 
 -compile([{parse_transform, lager_transform}]).
@@ -107,5 +108,13 @@ init_logging() ->
   lager:start(),
   lager:set_loglevel(lager_file_backend, debug),
   lager:set_loglevel(lager_console_backend, none),
-  %% io:format("Lager config:~n~s~n", [lager:status()]).
   ok.
+
+is_wz_supported() ->
+  try
+    ok = bitbucket:get_wz_branch_reviewers(<<"TOOLS">>, <<"bec-test">>),
+    true
+  catch _:_ ->
+      lager:error("Workzone plugin is not supported. Corresponding tests will not be run."),
+      false
+  end.

--- a/test/bec_test_utils.erl
+++ b/test/bec_test_utils.erl
@@ -11,10 +11,8 @@
 
 cmd(Fmt, Args) ->
   Cmd = lists:flatten(io_lib:format(Fmt, Args)),
-  %%io:format("Command: ~p~n", [Cmd]),
-  _Result = os:cmd(Cmd),
-  %%io:format("Command output: ~s~n", [Result]),
-  ok.
+  %% TODO log command output somewhere
+  os:cmd(Cmd).
 
 init_repo() ->
   Url           = os:getenv("BB_STAGING_URL", "http://localhost"),

--- a/test/bec_test_utils.erl
+++ b/test/bec_test_utils.erl
@@ -12,7 +12,8 @@
 cmd(Fmt, Args) ->
   Cmd = lists:flatten(io_lib:format(Fmt, Args)),
   %% TODO log command output somewhere
-  os:cmd(Cmd).
+  os:cmd(Cmd),
+  ok.
 
 init_repo() ->
   Url           = os:getenv("BB_STAGING_URL", "http://localhost"),

--- a/test/prop_api.erl
+++ b/test/prop_api.erl
@@ -205,8 +205,7 @@ get_hook_settings_next(S, _R, [_Key, _Slug, _Hook]) ->
   S.
 
 get_hook_settings_pre(S) ->
-  maps:get(configured_hooks, S) =/= [] andalso
-    maps:get(hooks, S) =/= [].
+  maps:get(configured_hooks, S) =/= [].
 
 get_hook_settings_pre(S, _Args) ->
   get_hook_settings_pre(S).
@@ -238,8 +237,7 @@ set_hook_settings_args(S) ->
         ]).
 
 set_hook_settings_pre(S) ->
-  maps:get(configured_hooks, S) =/= [] andalso
-    maps:get(hooks, S) =/= [].
+  maps:get(configured_hooks, S) =/= [].
 
 set_hook_settings_pre(S, _Args) ->
   set_hook_settings_pre(S).
@@ -431,14 +429,6 @@ prop_api() ->
 %% Setup
 %%==============================================================================
 
-is_wz_supported() ->
-  try
-    ok = bitbucket:get_wz_branch_reviewers(<<"TOOLS">>, <<"bec-test">>),
-    true
-  catch _:_ ->
-      false
-  end.
-
 setup() ->
   application:load(bec),
   %% Starting from OTP 21, error logger is not started by default any longer.
@@ -455,7 +445,7 @@ setup() ->
   bec_test_utils:init_bitbucket(),
   bec_test_utils:init_logging(),
   #{started => Started,
-    wz_supported => is_wz_supported()}.
+    wz_supported => bec_test_utils:is_wz_supported()}.
 
 
 %%==============================================================================
@@ -469,6 +459,8 @@ teardown(#{started := Started}) ->
 %%==============================================================================
 %% Internal Functions
 %%==============================================================================
+
+%% Return true for those hooks which are supported by BEC.
 is_hook_supported(<<"com.nerdwin15.stash-stash-webhook-jenkins:jenkinsPostReceiveHook">>) ->
   true;
 is_hook_supported(<<"de.aeffle.stash.plugin.stash-http-get-post-receive-hook:http-get-post-receive-hook">>) ->

--- a/test/prop_api.erl
+++ b/test/prop_api.erl
@@ -452,6 +452,8 @@ setup() ->
   application:set_env(bec, bitbucket_username, Username),
   application:set_env(bec, bitbucket_password, Password),
   {ok, Started} = application:ensure_all_started(bec),
+  bec_test_utils:init_bitbucket(),
+  bec_test_utils:init_logging(),
   #{started => Started,
     wz_supported => is_wz_supported()}.
 
@@ -460,6 +462,7 @@ setup() ->
 %% Teardown
 %%==============================================================================
 teardown(#{started := Started}) ->
+  bec_test_utils:deinit_bitbucket(),
   [application:stop(App) || App <- Started],
   ok.
 

--- a/test/prop_api.erl
+++ b/test/prop_api.erl
@@ -184,6 +184,8 @@ set_groups_post(_S, _Args, ok) ->
 get_hook_settings(Key, Slug, Hook) ->
   bitbucket:get_hook_settings(Key, Slug, Hook).
 
+get_hook_settings_args(#{hooks := []}) ->
+  true;
 get_hook_settings_args(S) ->
   ?LET( {Hook, _}
       , case maps:get(configured_hooks, S) of
@@ -203,10 +205,11 @@ get_hook_settings_next(S, _R, [_Key, _Slug, _Hook]) ->
   S.
 
 get_hook_settings_pre(S) ->
-  maps:get(configured_hooks, S) =/= [].
+  maps:get(configured_hooks, S) =/= [] andalso
+    maps:get(hooks, S) =/= [].
 
 get_hook_settings_pre(S, _Args) ->
-  maps:get(configured_hooks, S) =/= [].
+  get_hook_settings_pre(S).
 
 get_hook_settings_post(S, [_Key, _Slug, Hook], {ok, Settings}) ->
   case proplists:get_value(Hook, maps:get(configured_hooks, S)) of
@@ -223,6 +226,8 @@ get_hook_settings_post(S, [_Key, _Slug, Hook], {ok, Settings}) ->
 set_hook_settings(Key, Slug, Hook, Settings) ->
   bitbucket:set_hook_settings(Key, Slug, Hook, Settings).
 
+set_hook_settings_args(#{hooks := []}) ->
+  true;
 set_hook_settings_args(S) ->
   ?LET( Hook
       , oneof(maps:get(hooks, S))
@@ -231,6 +236,13 @@ set_hook_settings_args(S) ->
         , Hook
         , bec_proper_gen:hook_settings(Hook)
         ]).
+
+set_hook_settings_pre(S) ->
+  maps:get(configured_hooks, S) =/= [] andalso
+    maps:get(hooks, S) =/= [].
+
+set_hook_settings_pre(S, _Args) ->
+  set_hook_settings_pre(S).
 
 set_hook_settings_next(S, _R, [_Key, _Slug, Hook, Settings]) ->
   Hooks0 = maps:get(configured_hooks, S),

--- a/test/prop_yml.erl
+++ b/test/prop_yml.erl
@@ -49,4 +49,6 @@ setup() ->
   application:set_env(bec, bitbucket_user_a,   UserA),
   application:set_env(bec, bitbucket_user_b,   UserB),
   {ok, Started} = application:ensure_all_started(bec),
+  bec_test_utils:init_bitbucket(),
+  bec_test_utils:init_logging(),
   #{started => Started}.


### PR DESCRIPTION
This is a rather large PR which adds support for running the PropEr tests in `prop_api.erl` and `prop_yml.erl`. These tests require a running Bitbucket Server instance, which is the reason these have not been run before. This also caused problems because PRs opened against the GitHub repo were not being tested properly. (These tests were only run internally at Klarna.)

To spin up a Bitbucket Server instance, the `build.yml` workflow has been modified to start a Bitbucket service using the `atlassian/bitbucket-server:7.17.1` Docker image. It uses a "time-bomb" license retrieved from [here](https://developer.atlassian.com/platform/marketplace/timebomb-licenses-for-testing-server-apps/) which will automatically expire after three hours.

There is also a [docker-compose](https://docs.docker.com/compose/) setup in `scripts/pre-test-hook.sh` which is invoked automatically when running `rebar3 proper` locally. (Currently, to run these tests locally, you must use the `run-tests-with-bb.sh` script, but I hope to fix so that won't be necessary, and users should be able to just run `rebar3 proper` to test things, and things should "just work".
