### PR TITLE
Fix caching of plts in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,6 @@ jobs:
           ${{ runner.os }}-dialyzer-
     - name: Compile
       run: rebar3 as test compile
-    - name: Dialyzer
-      run: rebar3 dialyzer
     - name: Run EUnit Tests
       run: rebar3 eunit
     - name: Run CT Tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,9 @@ jobs:
     - name: Cache Dialyzer PLTs
       uses: actions/cache@v3
       with:
-        path: ~/.cache/rebar3/rebar3_*_plt
+        path: |
+          ~/.cache/rebar3/rebar3_*_plt
+          _build/**/*_plt
         key: ${{ runner.os }}-otp${{ matrix.otp-version }}-dialyzer-${{ hashFiles(format('{0}{1}', github.workspace, '/rebar.config')) }}
         restore-keys: |
           ${{ runner.os }}-otp${{ matrix.otp-version }}-dialyzer-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,9 +29,9 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.cache/rebar3/rebar3_*_plt
-        key: ${{ runner.os }}-dialyzer-${{ hashFiles(format('{0}{1}', github.workspace, '/rebar.config')) }}
+        key: ${{ runner.os }}-otp${{ matrix.otp-version }}-dialyzer-${{ hashFiles(format('{0}{1}', github.workspace, '/rebar.config')) }}
         restore-keys: |
-          ${{ runner.os }}-dialyzer-
+          ${{ runner.os }}-otp${{ matrix.otp-version }}-dialyzer-
     - name: Compile
       run: rebar3 as test compile
     - name: Run EUnit Tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Cache Dialyzer PLTs
       uses: actions/cache@v3
       with:
-        path: ~/.cache/rebar3/rebar3_*.plt
+        path: ~/.cache/rebar3/rebar3_*_plt
         key: ${{ runner.os }}-dialyzer-${{ hashFiles(format('{0}{1}', github.workspace, '/rebar.config')) }}
         restore-keys: |
           ${{ runner.os }}-dialyzer-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,14 +19,14 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Cache Hex packages
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cache/rebar3/hex/hexpm/packages
         key: ${{ runner.os }}-hex-${{ hashFiles(format('{0}{1}', github.workspace, '/rebar.lock')) }}
         restore-keys: |
           ${{ runner.os }}-hex-
     - name: Cache Dialyzer PLTs
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cache/rebar3/rebar3_*.plt
         key: ${{ runner.os }}-dialyzer-${{ hashFiles(format('{0}{1}', github.workspace, '/rebar.config')) }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/.cache/rebar3/hex/hexpm/packages
-        key: ${{ runner.os }}-hex-${{ hashFiles(format('{0}{1}', github.workspace, '/rebar.lock')) }}
+        key: ${{ runner.os }}-hex-${{ hashFiles('rebar.lock') }}
         restore-keys: |
           ${{ runner.os }}-hex-
     - name: Cache Dialyzer PLTs
@@ -31,7 +31,7 @@ jobs:
         path: |
           ~/.cache/rebar3/rebar3_*_plt
           _build/**/*_plt
-        key: ${{ runner.os }}-otp${{ matrix.otp-version }}-dialyzer-${{ hashFiles(format('{0}{1}', github.workspace, '/rebar.config')) }}
+        key: ${{ runner.os }}-otp${{ matrix.otp-version }}-dialyzer-${{ hashFiles('rebar.config') }}
         restore-keys: |
           ${{ runner.os }}-otp${{ matrix.otp-version }}-dialyzer-
     - name: Compile

--- a/rebar.config
+++ b/rebar.config
@@ -17,8 +17,7 @@
                         , deprecated_function_calls
                         , deprecated_functions
                         ]}.
-{dialyzer, [ {check_plt, true}
-           , {warnings, [unknown]}
+{dialyzer, [ {warnings, [unknown]}
            ]}.
 
 {profiles     , [ {prod, [ {relx, [ {dev_mode, false}, {include_erts, true}]}]}


### PR DESCRIPTION
Primary fix in this PR is that we observe that rebar3 uses `_plt`, not `.plt`, to name plt files.

Also in this PR:
* Include OTP version in cache key, to avoid builds for different OTP builds to clobber each other's caches
* Cache the locally build plt too (i.e. under `_build/**/*_plt`). This plt includes dependencies, as opposed to the ones under `~/.cache/rebar3/` which only includes OTP.