### PR TITLE
Replace lager with logger

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,6 @@
 {cover_enabled        , true}.
 {deps                 , [ {getopt,   "v0.8.2"}
                         , {jsx,      "2.8.0"}
-                        , {lager,    "3.9.1"}
                         , {mustache, {git, "https://github.com/mojombo/mustache.erl.git", {tag, "v0.1.1"}}}
                         , {yamerl,   "v0.6.0"}
                         ]}.

--- a/src/bec.app.src
+++ b/src/bec.app.src
@@ -8,7 +8,6 @@
                  , ssl
                  , inets
                  , goldrush
-                 , lager
                  , yamerl
                  , getopt
                  , mustache

--- a/src/bec.app.src
+++ b/src/bec.app.src
@@ -7,7 +7,6 @@
                  , stdlib
                  , ssl
                  , inets
-                 , goldrush
                  , yamerl
                  , getopt
                  , mustache

--- a/src/bitbucket.erl
+++ b/src/bitbucket.erl
@@ -3,7 +3,7 @@
 %%==============================================================================
 -module(bitbucket).
 
--compile([{parse_transform, lager_transform}]).
+-include_lib("kernel/include/logger.hrl").
 
 %%==============================================================================
 %% Exports
@@ -115,8 +115,8 @@ set_ssh_keys(ProjectKey, RepoSlug, Keys) ->
 get_default_branch(ProjectKey, RepoSlug) ->
   case bitbucket_api:get_default_branch(ProjectKey, RepoSlug) of
     {ok, Response} when Response =:= #{} ->
-      lager:error("Default branch not found. This might be because you haven't "
-                  "pushed any commits to the repo yet."),
+      ?LOG_ERROR("Default branch not found. This might be because you haven't "
+                 "pushed any commits to the repo yet."),
       throw(default_branch_not_found);
     {ok, Response} ->
       Branch = bec_branch_t:from_map(Response),

--- a/src/bitbucket_config.erl
+++ b/src/bitbucket_config.erl
@@ -2,13 +2,13 @@
 
 -export([ load/1 ]).
 
--compile([{parse_transform, lager_transform}]).
+-include_lib("kernel/include/logger.hrl").
 
 -spec load(string()) -> ok | {error, term()}.
 load(Path) ->
     case file:consult(Path) of
         {ok, Config} ->
-            lager:info("Reading config file ~p.~n", [Path]),
+            ?LOG_INFO("Reading config file ~p.~n", [Path]),
             [ok = application:set_env(bec, K, V) || {K, V} <- Config],
             ok;
         {error, Reason} ->

--- a/src/bitbucket_http.erl
+++ b/src/bitbucket_http.erl
@@ -3,8 +3,6 @@
 %%==============================================================================
 -module(bitbucket_http).
 
--compile([{parse_transform, lager_transform}]).
-
 %%==============================================================================
 %% Exports
 %%==============================================================================
@@ -14,6 +12,8 @@
         , post_request/2
         , put_request/2
         ]).
+
+-include_lib("kernel/include/logger.hrl").
 
 %%==============================================================================
 %% Types
@@ -71,7 +71,7 @@ put_request(Url, Body) ->
 do_request(Method, Url) ->
   Headers = headers(),
   Request = {Url, Headers},
-  ok      = lager:debug("HTTP Request: (~p) ~p~n", [Method, Url]),
+  ok      = ?LOG_DEBUG("HTTP Request: (~p) ~p~n", [Method, Url]),
   do_http_request(Method, Request).
 
 -spec do_request(method(), url(), body()) -> {ok, map()} | {error, any()}.
@@ -79,7 +79,7 @@ do_request(Method, Url, Body) ->
   Headers = headers(),
   Type    = "application/json",
   Request = {Url, Headers, Type, Body},
-  ok      = lager:debug("HTTP Request: (~p) ~p~n~p~n", [Method, Url, Headers]),
+  ok      = ?LOG_DEBUG("HTTP Request: (~p) ~p~n~p~n", [Method, Url, Headers]),
   do_http_request(Method, Request).
 
 -spec do_http_request(method(), request()) ->
@@ -93,7 +93,7 @@ do_http_request(Method, Request) ->
                                   , {max_sessions, 0}
                                   ]),
   Result      = httpc:request(Method, Request, HTTPOptions, Options),
-  ok          = lager:debug("HTTP Result: ~p~n", [Result]),
+  ok          = ?LOG_DEBUG("HTTP Result: ~p~n", [Result]),
   handle_result(Result).
 
 -spec headers() -> [{string(), string()}].

--- a/test/bec_test_utils.erl
+++ b/test/bec_test_utils.erl
@@ -7,7 +7,7 @@
         , is_wz_supported/0
         ]).
 
--compile([{parse_transform, lager_transform}]).
+-include_lib("kernel/include/logger.hrl").
 
 cmd(Fmt, Args) ->
   Cmd = lists:flatten(io_lib:format(Fmt, Args)),
@@ -104,16 +104,13 @@ deinit_bitbucket() ->
   catch bitbucket:delete_project(ProjectKey).
 
 init_logging() ->
-  lager:start(),
-  lager:set_loglevel(lager_file_backend, debug),
-  lager:set_loglevel(lager_console_backend, none),
-  ok.
+  ok = logger:update_primary_config(#{level => debug}).
 
 is_wz_supported() ->
   try
     ok = bitbucket:get_wz_branch_reviewers(<<"TOOLS">>, <<"bec-test">>),
     true
   catch _:_ ->
-      lager:error("Workzone plugin is not supported. Corresponding tests will not be run."),
+      ?LOG_ERROR("Workzone plugin is not supported. Corresponding tests will not be run."),
       false
   end.

--- a/test/bec_test_utils.erl
+++ b/test/bec_test_utils.erl
@@ -104,7 +104,26 @@ deinit_bitbucket() ->
   catch bitbucket:delete_project(ProjectKey).
 
 init_logging() ->
-  ok = logger:update_primary_config(#{level => debug}).
+  ok = logger:set_primary_config(level, all),
+  ok = logger:set_handler_config(default, level, critical),
+  ok = logger:update_formatter_config(
+         default,
+         #{ single_line => true
+          , legacy_header => false
+          }),
+  maybe_add_file_handler().
+
+maybe_add_file_handler() ->
+  FileHandlerId = file_handler,
+  case lists:member(FileHandlerId, logger:get_handler_ids()) of
+    true -> ok;
+    false ->
+      Filename = "log/bec.log",
+      io:format("Full BEC output sent to ~s~n", [Filename]),
+      ok = logger:add_handler(FileHandlerId, logger_std_h,
+                              #{config => #{file => Filename},
+                                level => all})
+  end.
 
 is_wz_supported() ->
   try

--- a/test/prop_api.erl
+++ b/test/prop_api.erl
@@ -430,10 +430,7 @@ prop_api() ->
 %%==============================================================================
 
 setup() ->
-  application:load(bec),
-  %% Starting from OTP 21, error logger is not started by default any longer.
-  %% See: https://github.com/erlang-lager/lager/issues/452
-  ok = application:set_env(lager, error_logger_redirect, false),
+  bec_test_utils:init_logging(),
   application:load(bec),
   Url           = os:getenv("BB_STAGING_URL", "http://localhost"),
   Username      = os:getenv("BB_STAGING_USERNAME", ""),
@@ -443,7 +440,6 @@ setup() ->
   application:set_env(bec, bitbucket_password, Password),
   {ok, Started} = application:ensure_all_started(bec),
   bec_test_utils:init_bitbucket(),
-  bec_test_utils:init_logging(),
   #{started => Started,
     wz_supported => bec_test_utils:is_wz_supported()}.
 


### PR DESCRIPTION
This PR removes the dependency on `lager` and replaces it with `logger`. Two fewer applications (`lager` and `goldrush`) and no parse-transforms. Log messages look slightly different, but verbosity levels should be identical. Specifically `-vvv` will dump all traffic, including possibly credentials encoded in hook urls, so be careful!
