### PR TITLE
Handle lowercase project ids

### DIFF
--- a/src/bitbucket_http.erl
+++ b/src/bitbucket_http.erl
@@ -80,7 +80,7 @@ do_request(Method, Url, Body) ->
   Type    = "application/json",
   Request = {Url, Headers, Type, Body},
   ok      = ?LOG_DEBUG("HTTP Request: (~p) ~p~n~p~n",
-                       [Method, Url, Headers, Body]),
+                       [Method, Url, Headers]),
   do_http_request(Method, Request).
 
 -spec do_http_request(method(), request()) ->

--- a/src/bitbucket_repo_config.erl
+++ b/src/bitbucket_repo_config.erl
@@ -73,6 +73,11 @@ read_template(TemplatePath, Variables) ->
 render(String, Ctx) ->
   mustache:render(String, Ctx).
 
+%% Convert a binary to upper-case.
+-spec binary_to_upper(Bin :: binary()) -> binary().
+binary_to_upper(Bin) ->
+  list_to_binary(string:to_upper(binary_to_list(Bin))).
+
 -spec do_verify(opts(), map()) -> boolean().
 do_verify(Options, Config) ->
   Project      = maps:get(<<"project">>, Config),
@@ -90,7 +95,10 @@ do_verify(Options, Config) ->
     {_, undefined} -> {error, missing_repo};
     {_, _}         ->
       NewConfig = remove_global_config(Config),
-      do_verify(Project, Repo, NewConfig, Enforce, AbortOnError)
+      %% Project key must be upper-case, or some pluging
+      %% (e.g. Workzone) may get confused.
+      do_verify(binary_to_upper(Project), Repo, NewConfig, Enforce,
+                AbortOnError)
   end.
 
 -spec do_verify(binary(), binary(), map(), boolean(), boolean()) -> boolean().

--- a/src/bitbucket_repo_config.erl
+++ b/src/bitbucket_repo_config.erl
@@ -182,7 +182,7 @@ do_verify(ProjectKey, RepoSlug, Key, Expected) ->
 equals(<<"branch-restrictions">>, Actual, Expected) ->
   Expected == [maps:remove(id, X) || X <- Actual];
 equals(<<"access-keys">>, Actual, Expected) ->
-  Expected == [maps:remove(id, X) || X <- Actual];
+  lists:sort(Expected) == lists:sort([maps:remove(id, X) || X <- Actual]);
 equals(<<"hooks">>, Actual, Expected) ->
   F = fun(Hook) -> lists:member(Hook, Actual) end,
   lists:all(F, Expected);

--- a/test/bec_test_utils.erl
+++ b/test/bec_test_utils.erl
@@ -3,6 +3,7 @@
 
 -export([ init_bitbucket/0
         , init_logging/0
+        , flush_logging/0
         , is_wz_supported/0
 
         , bitbucket_server_url/0
@@ -157,6 +158,10 @@ maybe_add_file_handler() ->
                               #{config => #{file => Filename},
                                 level => all})
   end.
+
+flush_logging() ->
+  logger_std_h:filesync(default),
+  logger_std_h:filesync(file_handler).
 
 is_wz_supported() ->
   try

--- a/test/prop_api.erl
+++ b/test/prop_api.erl
@@ -442,6 +442,7 @@ setup() ->
 %% Teardown
 %%==============================================================================
 teardown(#{started := Started}) ->
+  bec_test_utils:flush_logging(),
   [application:stop(App) || App <- Started],
   ok.
 

--- a/test/prop_yml.erl
+++ b/test/prop_yml.erl
@@ -18,16 +18,25 @@
 %% The property
 %%==============================================================================
 prop_yml() ->
-  setup(),
-  ?FORALL( Config
-         , bec_proper_gen:config()
-         , begin
-             Path = "/tmp/test.yml",
-             file:write_file(Path, bec_yml:encode(Config)),
-             bitbucket_repo_config:verify(Path, [{enforce, true}]),
-             bitbucket_repo_config:verify(Path)
-           end
-         ).
+  ?SETUP(
+     fun() ->
+         setup(),
+         fun cleanup/0
+     end,
+     ?WHENFAIL(
+        fun cleanup/0,
+        ?FORALL( Config
+               , bec_proper_gen:config()
+               , begin
+                   Path = "/tmp/test.yml",
+                   file:write_file(Path, bec_yml:encode(Config)),
+                   bitbucket_repo_config:verify(Path, [{enforce, true}]),
+                   bitbucket_repo_config:verify(Path)
+                 end
+               ))).
+
+cleanup() ->
+  bec_test_utils:flush_logging().
 
 %%==============================================================================
 %% Setup


### PR DESCRIPTION
Fixes bug #34 (Workzone plugin does not handle lowercase project ids), and also bug #58 (bitbucket does not preserve ssh key order).
